### PR TITLE
fix "rr" in quenya mode

### DIFF
--- a/modes/quenya.jsonc
+++ b/modes/quenya.jsonc
@@ -274,7 +274,7 @@ accent - lambe - malta + right curl.
     "mm": "{malta}[bar-below]", // "eMMa"
     "nn": "{nuumen}[bar-below]", // "aNNa"
     "pp": "{parma}[bar-below]", // "naPPa"
-    "rr": "{romen}[bar-below]", // "Palarran"
+    "rr": "{roomen}[bar-below]", // "Palarran"
     "ss": "{esse}", // "aSSa"
     "tt": "{tinco}[bar-below]" // "aTTa"
   },


### PR DESCRIPTION
the letter `roomen` was incorrectly spelt in the code, and shown in Tecendil as an invisible character