### PR TITLE
fix(spanish.jsonc): change calma by quesse in the definition of x

### DIFF
--- a/modes/spanish.jsonc
+++ b/modes/spanish.jsonc
@@ -273,7 +273,7 @@ accent - lambe - malta + right curl.
     "t": "{tinco}",
     "v": "{ampa}",
     "w": "{vala}",
-    "x": "{calma}[x-curl]",
+    "x": "{quesse}[x-curl]",
     "y": "{anca}",
     "z": "{suule}",
 


### PR DESCRIPTION
On line 276 the x was defined as `"x": "{calma}[x-curl]"`. I changed it to `"x": "{quesse}[x-curl]"`, per the [Lambenor site with the Spanish mode](http://lambenor.free.fr/tengwar/espanol_2006.html).