### PR TITLE
Do not overduplicate rr in Spanish mode

### DIFF
--- a/modes/spanish.jsonc
+++ b/modes/spanish.jsonc
@@ -70,7 +70,7 @@ accent - lambe - malta + right curl.
 
     // Strengthen "r" (-> "rr") at beginning or after consonant
     "^r": "rr",
-    "/([^AaEeIiOoUuÁáÉéÍíÓóÚú])r/": "$1rr"
+    "/([^AaEeIiOoUuÁáÉéÍíÓóÚúRr])r/": "$1rr"
   },
 
   "map": {


### PR DESCRIPTION
Fixes a problem with intervocalic "strong r" in Spanish, although #20 (initial "r") is not yet fixed