### PR TITLE
Add lojban mode

### DIFF
--- a/modes/lojban.jsonc
+++ b/modes/lojban.jsonc
@@ -1,0 +1,85 @@
+/*
+
+ LOJBAN MODE
+
+ This mode follows 'Elrond's revised mapping - mode 3', as documented at
+
+   http://www.raphael.poss.name/tengwar/
+
+ and as linked by
+
+   https://mw.lojban.org/papri/Tengwar
+
+*/
+{
+  "name": "lojban",
+  "languageCode": "jbo",
+
+  "normalizeVowels": false,
+
+  "preprocess": {
+    // Standard orthography says ' but h is in semi-common use too. Map here
+    // to avoid having to process separately.
+    "'": "h"
+  },
+
+  "map": {
+    // Always pusta for dot.
+    ".": "{pusta}",
+
+    // Separator
+    "h": "{halla}",
+
+    // Vowels
+    "^a": "{osse}",
+    "^e": "{yanta}",
+    "^i": "{telco}",
+    "^o": "{anna}",
+    "^u": "{vala}",
+    "^y": "{aara}",
+    "a": "[triple-dot-above]",
+    "e": "[acute]",
+    "i": "[dot-above]",
+    "o": "[right-curl]",
+    "u": "[left-curl]",
+    "y": "[dot-below]",
+
+    //
+    // Consonants
+    //
+    "t": "{tinco}",
+    "d": "{ando}",
+
+    "p": "{parma}",
+    "b": "{umbar}",
+
+    "k": "{quesse}",
+    "g": "{ungwe}",
+
+    "f": "{formen}",
+    "v": "{ampa}",
+
+    "c": "{harma}",
+    "j": "{anca}",
+
+    // Later - s & z should not be nuquerna if followed by consonant, or at end of word.
+    "s": "{silme-nuquerna}",
+    "z": "{esse-nuquerna}",
+
+    "x": "{hwesta}",
+
+    "m": "{malta}",
+    "n": "{nuumen}",
+
+    // Later - r should be roomen if followed by consonant, or at end of word.
+    "r": "{oore}",
+    "l": "{lambe}"
+  },
+
+  "words": {
+    // Special for bridi, topic, and end of text separators
+    ".i": "{double-pusta}",
+    "niho": "{triple-pusta}",
+    "faho": "{quadruple-pusta}"
+  }
+}

--- a/modes/lojban.jsonc
+++ b/modes/lojban.jsonc
@@ -2,7 +2,8 @@
 
  LOJBAN MODE
 
- This mode follows 'Elrond's revised mapping - mode 3', as documented at
+ This mode attempts to follow 'Elrond's revised mapping - mode 3', as
+ documented at
 
    http://www.raphael.poss.name/tengwar/
 
@@ -10,12 +11,21 @@
 
    https://mw.lojban.org/papri/Tengwar
 
+ There are some omissions:
+
+ - S curls at the end of cmene.
+ - commas and capitals for indicating stress.
+ - Diphthong usage in samples appears to be irregular. I've gone for what I
+   believe is the most beautiful of the alternatives provided.
+
 */
 {
-  "name": "lojban",
+  "name": "jbobau (Lojban)",
   "languageCode": "jbo",
 
   "normalizeVowels": false,
+
+  "wordPattern": "^[A-Za-zÀ-ÖØ-öø-ÿ\\*\\'\\.]+",
 
   "preprocess": {
     // Standard orthography says ' but h is in semi-common use too. Map here
@@ -31,18 +41,63 @@
     "h": "{halla}",
 
     // Vowels
+
+    // At the start of words, use the free-standing vowels.
     "^a": "{osse}",
     "^e": "{yanta}",
     "^i": "{telco}",
     "^o": "{anna}",
     "^u": "{vala}",
     "^y": "{aara}",
-    "a": "[triple-dot-above]",
-    "e": "[acute]",
-    "i": "[dot-above]",
-    "o": "[right-curl]",
-    "u": "[left-curl]",
-    "y": "[dot-below]",
+
+    // Normal tehta for following vowels. These are commented out as it
+    // matches default rules.
+    // "a": "[triple-dot-above]",
+    // "e": "[acute]",
+    // "i": "[dot-above]",
+    // "o": "[right-curl]",
+    // "u": "[left-curl]",
+    // "y": "[dot-below]",
+
+    // Full vowels following halla - halla never gets tehta.
+    "ha": "{halla}{osse}",
+    "he": "{halla}{yanta}",
+    "hi": "{halla}{telco}",
+    "ho": "{halla}{anna}",
+    "hu": "{halla}{vala}",
+    "hy": "{halla}{aara}",
+
+    // Full vowels following pusta. Note .i also makes the validator sad, but
+    // it is necessary for everything to come out right.
+    ".a": "{pusta}{osse}",
+    ".e": "{pusta}{yanta}",
+    ".i": "{pusta}{telco}",
+    ".o": "{pusta}{anna}",
+    ".u": "{pusta}{vala}",
+    ".y": "{pusta}{aara}",
+
+    // Explicit mapping for diphthongs - these should not combine with the
+    // preceding consonant. Note that the validator says these are not
+    // necessary, but they are! Otherwise 'bai' comes out as
+    // {umbar}[triple-dot-above]{telco}[dot-above] - with this it correctly
+    // comes out as {umbar}{osse}[dot-above].
+
+    "ai": "{osse}[dot-above]",
+    "au": "{osse}[left-curl]",
+    "ei": "{yanta}[dot-above]",
+    "ia": "{telco}[triple-dot-above]",
+    "ie": "{telco}[acute]",
+    "ii": "{telco}[dot-above]",
+    "io": "{telco}[right-curl]",
+    "iu": "{telco}[left-curl]",
+    "iy": "{telco}[dot-below]",
+    "oi": "{anna}[dot-above]",
+    "ua": "{vala}[triple-dot-above]",
+    "ue": "{vala}[acute]",
+    "ui": "{vala}[dot-above]",
+    "uo": "{vala}[right-curl]",
+    "uu": "{vala}[left-curl]",
+    "uy": "{vala}[dot-below]",
 
     //
     // Consonants
@@ -62,24 +117,98 @@
     "c": "{harma}",
     "j": "{anca}",
 
-    // Later - s & z should not be nuquerna if followed by consonant, or at end of word.
-    "s": "{silme-nuquerna}",
-    "z": "{esse-nuquerna}",
+    // s & z should be nuquerna if they have a tehta. This require specific
+    // definitions of all SV combos. And then, because we've defined these, we
+    // need to re-define all SVV combos to get the combining forms right.
+    "s": "{silme}",
+    "sa": "{silme-nuquerna}[triple-dot-above]",
+    "se": "{silme-nuquerna}[acute]",
+    "si": "{silme-nuquerna}[dot-above]",
+    "so": "{silme-nuquerna}[right-curl]",
+    "su": "{silme-nuquerna}[left-curl]",
+    "sy": "{silme-nuquerna}[dot-below]",
+    "sai": "{silme}{osse}[dot-above]",
+    "sau": "{silme}{osse}[left-curl]",
+    "sei": "{silme}{yanta}[dot-above]",
+    "sia": "{silme}{telco}[triple-dot-above]",
+    "sie": "{silme}{telco}[acute]",
+    "sii": "{silme}{telco}[dot-above]",
+    "sio": "{silme}{telco}[right-curl]",
+    "siu": "{silme}{telco}[left-curl]",
+    "siy": "{silme}{telco}[dot-below]",
+    "soi": "{silme}{anna}[dot-above]",
+    "sua": "{silme}{vala}[triple-dot-above]",
+    "sue": "{silme}{vala}[acute]",
+    "sui": "{silme}{vala}[dot-above]",
+    "suo": "{silme}{vala}[right-curl]",
+    "suu": "{silme}{vala}[left-curl]",
+    "suy": "{silme}{vala}[dot-below]",
+    "z": "{esse}",
+    "za": "{esse-nuquerna}[triple-dot-above]",
+    "ze": "{esse-nuquerna}[acute]",
+    "zi": "{esse-nuquerna}[dot-above]",
+    "zo": "{esse-nuquerna}[right-curl]",
+    "zu": "{esse-nuquerna}[left-curl]",
+    "zy": "{esse-nuquerna}[dot-below]",
+    "zai": "{esse}{osse}[dot-above]",
+    "zau": "{esse}{osse}[left-curl]",
+    "zei": "{esse}{yanta}[dot-above]",
+    "zia": "{esse}{telco}[triple-dot-above]",
+    "zie": "{esse}{telco}[acute]",
+    "zii": "{esse}{telco}[dot-above]",
+    "zio": "{esse}{telco}[right-curl]",
+    "ziu": "{esse}{telco}[left-curl]",
+    "ziy": "{esse}{telco}[dot-below]",
+    "zoi": "{esse}{anna}[dot-above]",
+    "zua": "{esse}{vala}[triple-dot-above]",
+    "zue": "{esse}{vala}[acute]",
+    "zui": "{esse}{vala}[dot-above]",
+    "zuo": "{esse}{vala}[right-curl]",
+    "zuu": "{esse}{vala}[left-curl]",
+    "zuy": "{esse}{vala}[dot-below]",
 
     "x": "{hwesta}",
 
     "m": "{malta}",
     "n": "{nuumen}",
 
-    // Later - r should be roomen if followed by consonant, or at end of word.
-    "r": "{oore}",
-    "l": "{lambe}"
+    "l": "{lambe}",
+    // R has the same rules as s & z, except oore if it has a tehta.
+    "r": "{roomen}",
+    "ra": "{oore}[triple-dot-above]",
+    "re": "{oore}[acute]",
+    "ri": "{oore}[dot-above]",
+    "ro": "{oore}[right-curl]",
+    "ru": "{oore}[left-curl]",
+    "ry": "{oore}[dot-below]",
+    "rai": "{roomen}{osse}[dot-above]",
+    "rau": "{roomen}{osse}[left-curl]",
+    "rei": "{roomen}{yanta}[dot-above]",
+    "ria": "{roomen}{telco}[triple-dot-above]",
+    "rie": "{roomen}{telco}[acute]",
+    "rii": "{roomen}{telco}[dot-above]",
+    "rio": "{roomen}{telco}[right-curl]",
+    "riu": "{roomen}{telco}[left-curl]",
+    "riy": "{roomen}{telco}[dot-below]",
+    "roi": "{roomen}{anna}[dot-above]",
+    "rua": "{roomen}{vala}[triple-dot-above]",
+    "rue": "{roomen}{vala}[acute]",
+    "rui": "{roomen}{vala}[dot-above]",
+    "ruo": "{roomen}{vala}[right-curl]",
+    "ruu": "{roomen}{vala}[left-curl]",
+    "ruy": "{roomen}{vala}[dot-below]"
   },
 
   "words": {
-    // Special for bridi, topic, and end of text separators
+    // Special for bridi and topic separators.
     ".i": "{double-pusta}",
-    "niho": "{triple-pusta}",
-    "faho": "{quadruple-pusta}"
+    "niho": "{dash}",
+    "ni'o": "{dash}",
+    // Bar inside la le li lo lu to make them stand out.
+    "la": "{lambe}[bar-inside][triple-dot-above]",
+    "le": "{lambe}[bar-inside][acute]",
+    "li": "{lambe}[bar-inside][dot-above]",
+    "lo": "{lambe}[bar-inside][right-curl]",
+    "lu": "{lambe}[bar-inside][left-curl]"
   }
 }

--- a/strings.json
+++ b/strings.json
@@ -55,6 +55,8 @@
     "menu.mode.beleriand": "Beleriand",
     "label.mode.erebor": "Cirth",
     "menu.mode.erebor": "Cirth: Angerthas Erebor",
+    "label.mode.lojban": "Lojban",
+    "menu.mode.lojban": "jbobau (Lojban)",
 
     "warning.general": "<p><b>CAUTION</b> This transcriber only works well for some languages. The result may be inaccurate otherwise.</p>",
     "warning.english": "<p><b>CAUTION</b> Tecendil does not translate. What you typed looks like English. For an accurate transcription, select an English mode.</p>",
@@ -148,6 +150,7 @@
     "menu.mode.beleriand": "Beleriand",
     "label.mode.erebor": "Cirth",
     "menu.mode.erebor": "Cirth: Angerthas Erebor",
+    "label.mode.lojban": "Lojban",
 
     "warning.general": "<p><b>POZOR</b> Tento přepis funguje dobře jen pro angličtinu, španělštinu, sindarština a quenijštinu. Výsledný přepis může být nepřesný.</p>",
     "warning.english": "<p><b>POZOR</b> Tecendil nepřekládá. Co píšete vypadá jako angličtina. Pro správný přepis angličtiny se přepněte do anglického módu.</p>",
@@ -228,6 +231,7 @@
     "label.mode.erebor": "Cirth",
     "menu.mode.westron": "Westron orthographisch",
     "label.mode.westron": "Westron",
+    "label.mode.lojban": "Lojban",
 
     "warning.general": "<p><b>VORSICHT</b> Dieser Transkriptor funktioniert nur gut für Englisch, Spanisch, Sindarin oder Quenya. Das Ergebnis kann sonst ungenau sein.</p>",
     "warning.elvish": "<p><b>VORSICHT</b>Das sieht nicht nach Englisch aus. Ist das Sindarin oder Quenya? Für eine genaue Transkription wählen Sie den Sindarin-, Quenya- oder Beleriand-Modus</p>",
@@ -302,6 +306,7 @@
     "label.mode.erebor": "cirth",
     "menu.mode.westron": "Westron ortográfico",
     "label.mode.westron": "westron",
+    "label.mode.lojban": "Lojban",
 
     "warning.general": "<p><b>ATENCIÓN</b> Este transcriptor solo trabaja para inglés, español, sindarin o quenya. El resultado puede ser inexacto de lo contrario.</p>",
     "warning.elvish": "<p><b>ATENCIÓN</b>Esto no se parece al inglés. ¿Es esto sindarin o quenya? Para una transcripción precisa, seleccione el modo Sindarin, Quenya o Beleriand</p>",
@@ -375,6 +380,7 @@
     "label.mode.erebor": "cirth",
     "menu.mode.westron": "Westron orthographique",
     "label.mode.westron": "westron",
+    "label.mode.lojban": "Lojban",
 
     "warning.general": "<p><b>ATTENTION</b> Ce transcripteur ne fonctionne que pour certaines langues. Le résultat peut être inexact autrement.</p>",
     "warning.elvish": "<p><b>ATTENTION</b> Cela ne ressemble pas à l'anglais. Est-ce Sindarin ou Quenya? Pour une transcription précise, sélectionnez le mode Sindarin, Quenya ou Beleriand.</p>",
@@ -447,6 +453,7 @@
     "label.mode.quenya": "Quenya",
     "label.mode.beleriand": "Beleriand",
     "label.mode.erebor": "Cirth",
+    "label.mode.lojban": "Lojban",
 
     "warning.general": "<p><b>ATTENZIONE</b> Questo trascrittore funziona bene solo per l'inglese, spagnolo, Sindarin o Quenya. Il risultato potrebbe non essere accurato altrimenti.</p>",
     "warning.elvish": "<p><b>ATTENZIONE</b>Questo non sembra inglese. È Sindarin o Quenya? Per una trascrizione precisa, seleziona la modalità Sindarin, Quenya o Beleriand.</p>",
@@ -527,6 +534,7 @@
     "menu.mode.derdzinski-polish": "polski – metodą Derdzińskiego",
     "label.mode.erebor": "Cirth",
     "menu.mode.erebor": "Cirth: Angerthas Erebor",
+    "label.mode.lojban": "Lojban",
 
     "warning.general": "<p><b>CAUTION</b> This transcriber only works well for English, Spanish, Sindarin or Quenya. The result may be inaccurate otherwise.</p>",
     "warning.english": "<p><b>CAUTION</b> Tecendil does not translate. What you typed looks like English. For an accurate transcription, select an English mode.</p>",
@@ -609,6 +617,7 @@
     "label.mode.beleriand": "贝尔兰",
     "menu.mode.beleriand": "Beleriand（贝尔兰）",
     "label.mode.erebor": "切斯文",
+    "label.mode.lojban": "逻辑语",
 
     "warning.general": "<p><b>警告</b> 此转写器只适用于英语、西班牙语、辛达林语或昆雅语。 否则结果可能不准确。</p>",
     "warning.elvish": "<p><b>警告</b> 这看起来不像英语。 这是辛达林语还是昆雅语？ 要获得准确的转录，请选择Sindarin，Quenya或Beleriand模式。</p>",
@@ -688,6 +697,7 @@
     "label.mode.beleriand": "貝爾蘭",
     "menu.mode.beleriand": "Beleriand（貝爾蘭）",
     "label.mode.erebor": "切斯文",
+    "label.mode.lojban": "逻辑语",
 
     "warning.general": "<p><b>警告</b> 這個抄寫員只適用於英語，西班牙語，辛達林語或昆雅語。 否則結果可能不准確。</p>",
     "warning.elvish": "<p><b>警告</b> 这看起来不像英语。 这是辛达林还是昆雅？ 要获得准确的转录，请选择Sindarin，Quenya或Beleriand模式。</p>",
@@ -772,6 +782,7 @@
     "menu.mode.beleriand": "Beleriand（貝爾蘭）",
     "label.mode.erebor": "切斯文",
     "menu.mode.erebor": "Cirth: Angerthas Erebor（切斯文：伊魯伯字體）",
+    "label.mode.lojban": "邏輯語",
 
     "warning.general": "<p><b>警告</b> 這個轉寫器只適用於英語，西班牙語，辛達林語或昆雅語。 否則結果可能不准確。</p>",
     "warning.elvish": "<p><b>警告</b> 這個看起來不像是英語。這是辛達林語或昆雅語嗎？要獲得準確的轉錄，請選擇Sindarin，Quenya或Beleriand模式。</p>",


### PR DESCRIPTION
This adds a lojban mode! I've linked spec documents in the header comments.

From playing around, it appears to do the right thing. It messes up if you write invalid lojban words, but I figure that's fine because then you wouldn't be picking lojban mode.

There could be an issue where some folks prefer to write e.g. 'lo nu' as 'lonu', but I've not handled this. It'd just mean you don't get the emphasizing bar inside the 'lo'.