### PR TITLE
Add German orthographic mode

### DIFF
--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -19,6 +19,33 @@
 
   "preprocess":
   {
+    // Ensure that ii and uu are not interpreted as long vowels by the
+    // built-in rules.
+    "ii": "i'i",
+    "uu": "u'u",
+
+
+    // -i diphthongs with {anna}
+    "ai": "aj",
+    "ei": "ej",
+    // -u diphthongs with {vala}
+    "au": "aw",
+    "eu": "ew",
+
+
+    // Replace c+vowel by z or k, depending on following vowel
+    // c -> z
+    "cä": "zä",
+    "ce": "ze",
+    "ci": "zi",
+    "cö": "zö",
+    "cy": "zy",
+
+    // c -> k
+    "ca": "ka",
+    "co": "ko",
+    "cu": "ku",
+    "cü": "kü"
   },
 
   "map":
@@ -27,11 +54,32 @@
     //
     // VOWELS
     //
+    // a,e,i,o,u,y: built-in rules
+    "ä": "[reversed-triple-dot-above]",
+    "ö": "[double-acute]",
+    "ü": "[double-dot-above]",
 
     // -----------------------------------------------------------------------
     //
-    // DIPHTHONGS
+    // DIPHTHONGS AND DOUBLE VOWELS
     //
+    // -a
+    "aa": "[triple-dot-above]{osse}",
+    // -e
+    // TODO explain that we do not transcribe ae, oe, ue as diphthongs
+    "ee": "[acute]{yanta}",
+    // TODO non-diphthong ie like 'petersilie', 'serviette'
+    "ie": "[dot-above]{yanta}",
+    // -i
+    // ai and ei handled by preprocessing
+    // TODO oi/ui. Sometimes diphthong, sometimes o-i.
+    // -o
+    // implemented by built-in rule
+    // "oo": "[double-right-curl]",
+    // -u
+    // au and eu handled by preprocessing
+
+    // TODO consonantic i (ia, io, iu) in certain situations
 
 
     // -----------------------------------------------------------------------
@@ -41,7 +89,7 @@
     "t": "{tinco}",
     "d": "{ando}",
     "n": "{nuumen}",
-	"z": "{extended-tinco}",
+    "z": "{extended-tinco}",
     // r ore implemented by rrule
 
     // -----------------------------------------------------------------------
@@ -53,20 +101,20 @@
     "v": "{ampa}",
     "m": "{malta}",
     "w": "{vala}",
-	// TODO check for problems at morphem boundaries
-	"pf" : "{extended-parma}"
+    // TODO check for problems at morphem boundaries
+    "pf" : "{extended-parma}",
 
     // -----------------------------------------------------------------------
     //
     // CONSONANTS: POSTALVEOLARS/PALATALS (SCH VARIANTS AND J)
-	// TODO check for problems at morphem boundaries
+    // TODO check for problems at morphem boundaries
     "tsch": "{calma}",
-	// TODO: maybe only for foreign words like dschungel and remove from map
-	// because of words like 'Grundschule'
+    // TODO: maybe only for foreign words like dschungel and remove from map
+    // because of words like 'Grundschule'
     "dsch": "{anga}",
-	// TODO check for problems at morphem boundaries
+    // TODO check for problems at morphem boundaries
     "sch": "{harma}",
-	// TODO: anca could be used for voiced sch as in 'garage'
+    // TODO: anca could be used for voiced sch as in 'garage'
     "j": "{anna}",
 
     // -----------------------------------------------------------------------
@@ -74,35 +122,48 @@
     // CONSONANTS: VELARS
     "k": "{quesse}",
     "g": "{ungwe}",
-	// TODO: note on the two distinct sounds
+    // TODO: note on the two distinct sounds
     "ch": "{hwesta}",
-	// TODO: exceptions like Kongo, Mango, ungerade
-	"ng": "{nwalme}",
+    // TODO: exceptions like Kongo, Mango, ungerade
+    "ng": "{nwalme}",
 
     // -----------------------------------------------------------------------
     //
-    // CONSONANTS: MISC
-	// r romen implemented by rrule
-	// TODO: check for problems at morphem boundaries
+    // CONSONANTS: MISC SINGLE TENGWAR
+    // r romen implemented by rrule
+    // TODO: check for problems at morphem boundaries
     "rh": "{arda}",
-	"l": "{lambe}",
-	// TODO: silme nuquerna with tengwar
-	"s": "{silme}",
-	// TODO: check for problems at morphem boundaries / check triple s
-	"ss": "{esse}",
-	// TODO ß
-	// TODO: Dehnungs-h
-	"h": "{hyarnen}"
+    "l": "{lambe}",
+    "s": "{silme}", // automatically becomes nuquerna with tengwar
+    // TODO: check for problems at morphem boundaries / check triple s
+    "ss": "{esse}", // automatically becomes nuquerna with tengwar
+    // TODO explain (e.g., Masse/Maße)
+    "ß": "{thuule}",
+    // TODO ß
+    // TODO: Dehnungs-h
+    // TODO: consonantic y
+    "h": "{hyarmen}",
 
-	// TODO: consonant diacritics (-h, double, nasal, final s, following w)
-	// TODO: c
-	// TODO: ck
-	// TODO: sp, st
-	// TODO: tz
-	// TODO: x
-	// TODO: Q ->K, QU -> KW
-	// TODO: consonant diacritics (-h, double, nasal, final s
+    // -----------------------------------------------------------------------
+    //
+    // CONSONANTS: SINGLE CONSONANT SPECIAL CASES
+    // This is only used if the following letter is not a vowel (these are
+    // handled by preprocessing) and the c is not part of one of the
+    // multiconsonant graphems below.
+    "c": "{quesse}",
+    // We should not use preprocess to k(w) here because of words like
+    // 'Backware'
+    "qu": "[over-twist]{quesse}",
+    // Does this ever happen?
+    "q": "{quesse}",
+    // We should preprocess too ks here because of words like 'wirksam'
+    "x": "[right-curl-below]{quesse}"
 
+    // TODO: consonant diacritics (-h, double, nasal, final s, following w)
+    // TODO: ck
+    // TODO: sp, st
+    // TODO: tz
+    // TODO: consonant diacritics (-h, double, nasal, final s)
   },
 
   "words":

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -390,7 +390,7 @@
     // As of now, -e/-s/-es is only encoded for cases that can appear at the
     // actual end of a word. More combinations are possible when -e/-s/-es
     // appear as a Fugenlaut.
-    
+
     // TODO LATER add -e/-s/-es combinations for Fugenlaut.
 
     // -----------------------------------------------------------------------
@@ -403,6 +403,13 @@
     //
     // FINAL -S
     // also should not be used after vowel
+
+    // -ahs, -ohs, do not occur TODO LATER CHECK
+    // TODO LATER check if -ähs, -öhs, -ühs occur
+    // NOTES: Only looks good in some fonts.
+    "ehs$": "[acute][hook]{aara}",
+    "uhs$": "[left-curl][hook]{aara}",
+
     "aas$": "[triple-dot-above][hook]{osse}",
     "ees$": "[acute][hook]{yanta}",
     "ies$": "[dot-above][hook]{yanta}",
@@ -432,7 +439,6 @@
     "ngs$": "[hook]{nwalme}",
 
     "ls$": "[hook]{lambe}",
-    // TODO: Dehnungs-h + s
 
     "cs$": "[hook]{quesse}",
     // -qus, -qs, -xs does not occur TODO LATER CHECK
@@ -468,6 +474,14 @@
     // -----------------------------------------------------------------------
     //
     // FINAL -ES
+    // -ehes, öhes do not occur TODO LATER CHECK
+    "ahes$": "[triple-dot-above][hook][dot-below]{aara}",
+    "ehes$": "[acute][hook][dot-below]{aara}",
+    "ohes$": "[right-curl][hook][dot-below]{aara}",
+    "uhes$": "[left-curl][hook][dot-below]{aara}",
+    "ähes$": "[reversed-triple-dot-above][hook][dot-below]{aara}",
+    "ühes$": "[double-dot-above][hook][dot-below]{aara}",
+
     // -aaes, -eees, -iees, -yoes do not occur TODO LATER CHECK
     "aies$": "[triple-dot-above][hook][dot-below]{anna}",
     "eies$": "[acute][hook][dot-below]{anna}",
@@ -498,7 +512,6 @@
     "nges$": "[hook][dot-below]{nwalme}",
 
     "les$": "[hook][dot-below]{lambe}",
-    // TODO: Dehnungs-h + es
 
     // -ces, -ques, -qes does not occur TODO LATER CHECK
     "xes$": "[right-curl-below][hook][dot-below]{quesse}",

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -242,7 +242,7 @@
 
     // ntsch, ndsch do not occur TODO CHECK
     "nsch": "[tilde-above]{harma}",
-    // nj better handled as n + palatalization symbol
+    "nj": "[tilde-above]{anna}",
 
     "nk": "[tilde-above]{quesse}",
     // TODO ng-g cases
@@ -278,7 +278,9 @@
     "ssion": "[double-dot-inside]{esse}[right-curl]{nuumen}",
     "tion": "[double-dot-below]{extended-tinco}[right-curl]{nuumen}",
 
-    // TODO NOTES on -E/-S in composites
+    // TODO NOTES on -E/-S in composites. We could add more -s/-es rules to
+    // allow for encoding in composites when an apostroph is input at the
+    // morphem boundary. The rules here are for actual word endings only.
 
     // -----------------------------------------------------------------------
     //
@@ -332,6 +334,23 @@
     "cks$": "[bar-below][hook]{quesse}",
     "lls$": "[bar-below][hook]{lambe}",
 
+    // -schws, -zws do not occur
+    
+    // -rhs, -ghs, do not occur TODO CHECK
+    "ths$": "[thinnas][hook]{tinco}",
+    "phs$": "[thinnas][hook]{parma}",
+
+    // -nzs, -mbs, -mfs, -mws, -nschs, -njs, -nchs do not occur TODO CHECK
+    "nts$": "[tilde-above][hook]{tinco}",
+    "nds$": "[tilde-above][hook]{ando}",
+    "mps$": "[tilde-above][hook]{parma}",
+    "mpfs$" : "[tilde-above][hook]{extended-parma}",
+    "nks$": "[tilde-above][hook]{quesse}",
+    "ncks$": "[tilde-above][bar-below][hook]{quesse}",
+    "nths$": "[tilde-above][thinnas][hook]{tinco}",
+    "mphs$": "[tilde-above][thinnas][hook]{parma}",
+
+    // -sions, -ssions, -tions do not occur TODO CHECK
 
     // -----------------------------------------------------------------------
     //
@@ -382,13 +401,30 @@
     "ffes$": "[bar-below][hook][dot-below]{formen}",
     "mmes$": "[bar-below][hook][dot-below]{malta}",
     "ckes$": "[bar-below][hook][dot-below]{quesse}",
-    "lles$": "[bar-below][hook][dot-below]{lambe}"
+    "lles$": "[bar-below][hook][dot-below]{lambe}",
 
+    // -schwes, -zwes do not occur
 
+    // -rhes, -ghes, do not occur TODO CHECK
+    // possible, but does not look good
+    // "thes$": "[thinnas][hook][dot-below]{tinco}",
+    // "phes$": "[thinnas][hook][dot-below]{parma}"
 
+    // -mfes, -mwes, -njes, -nckes do not occur TODO CHECK
+    "ntes$": "[tilde-above][hook][dot-below]{tinco}",
+    "ndes$": "[tilde-above][hook][dot-below]{ando}",
+    "nzes$": "[tilde-above][hook][dot-below]{extended-tinco}",
+    "mpes$": "[tilde-above][hook][dot-below]{parma}",
+    "mbes$": "[tilde-above][hook][dot-below]{umbar}",
+    "mpfes$" : "[tilde-above][hook][dot-below]{extended-parma}",
+    "nsches$": "[tilde-above][hook][dot-below]{harma}",
+    "nkes$": "[tilde-above][hook][dot-below]{quesse}",
+    "nches$": "[tilde-above][hook][dot-below]{hwesta}"
+    // possible, but does not look good
+    // "nthes$": "[tilde-above][thinnas][hook][dot-below]{tinco}",
+    // "mphes$": "[tilde-above][thinnas][hook][dot-below]{parma}"
 
-
-
+    // -siones, -ssiones, -tiones do not occur TODO CHECK
   },
 
   "words":

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -132,7 +132,6 @@
     "ss": "{esse}", // automatically becomes nuquerna with tengwar
     // TODO explain (e.g., Masse/Maße)
     "ß": "{thuule}",
-    // TODO ß
     // TODO: Dehnungs-h
     // TODO: consonantic y
     "h": "{hyarmen}",
@@ -154,6 +153,42 @@
 
     // -----------------------------------------------------------------------
     //
+    // CONSONANTS: DOUBLED CONSONANTS
+    // Note: tripled consonants are handled correctly, i.e., ff-f, same is
+    // true for ck-k
+    // TODO check for problems at morphem boundaries
+    "tt": "[bar-below]{tinco}",
+    "dd": "[bar-below]{ando}",
+    "nn": "[bar-below]{nuumen}",
+    "rr": "[bar-below]{roomen}",
+    "zz": "[bar-below]{extended-tinco}",
+    "tz": "[bar-below]{extended-tinco}",
+
+    "pp": "[bar-below]{parma}",
+    "bb": "[bar-below]{umbar}",
+    "ff": "[bar-below]{formen}",
+    // vv does not occur
+    "mm": "[bar-below]{malta}",
+    // ww does not occur
+
+    "kk": "[bar-below]{quesse}",
+    "ck": "[bar-below]{quesse}",
+    // TODO: cce not working because of preprocessing
+    "cc": "[bar-below]{quesse}",
+    "gg": "[bar-below]{ungwe}",
+
+    "ll": "[bar-below]{lambe}",
+
+    // -----------------------------------------------------------------------
+    //
+    // CONSONANTS: -W
+    "schw": "[over-twist]{harma}",
+    "zw": "[over-twist]{extended-tinco}",
+    // tz-w occours only in composites tz-w, therefore there is no over-twist.
+    // This is already correctly handled because of the tz rule before.
+
+    // -----------------------------------------------------------------------
+    //
     // CONSONANTS: -H
     // TODO: this could cause too many problems with composites. could be
     // better to put the
@@ -166,15 +201,19 @@
 
     // -----------------------------------------------------------------------
     //
-    // CONSONANTS: FINAL -E and -S
-    // TODO use prettier inside dots for "large" tengwar
-    "e$": "[dot-below]",
+    // CONSONANTS: FINAL -E
+    // TODO CHECK WITH NEW STUFF
+    "e$": "[dot-below]"
+
+    // -----------------------------------------------------------------------
+    //
+    // CONSONANTS: FINAL -S
     // TODO: check, does not work with some consonantsn
     // also should not be used after vowel
-    "s$": "[hook]",
+    // "s$": "[hook]",
     // TODO: does not work; the diacritic encondings should be before the
     // tengwar (but this is ok for e$ above)
-    "es$": "[hook][dot-below]"
+    //"es$": "[hook][dot-below]"
 
   },
 

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -70,6 +70,18 @@
 
     // -----------------------------------------------------------------------
     //
+    // DEHNUNGS-H
+    // TODO DISCUSS
+    "ah": "[triple-dot-above]{aara}",
+    "eh": "[acute]{aara}",
+    "oh": "[right-curl]{aara}",
+    "uh": "[left-curl]{aara}",
+    "äh": "[reversed-triple-dot-above]{aara}",
+    "öh": "[double-acute]{aara}",
+    "üh": "[double-dot-above]{aara}",
+
+    // -----------------------------------------------------------------------
+    //
     // DIPHTHONGS AND DOUBLE VOWELS
     //
     // -a
@@ -91,6 +103,8 @@
     "eu": "[acute]{vala}",
     // -y when not handled by preprocess
     "oy": "[right-curl]{anna}",
+
+    // TODO use thinnas for diphthong+h, maybe only at end of word?
 
     // TODO consonantic i (ia, io, iu) in certain situations?
 

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -2,14 +2,43 @@
 //
 // GERMAN ORTHOGRAPHIC MODE
 //
-// ---------------------------------------------------------------------------
-
-// TODO ADD SOURCES, EXPLANATION, ...
-
+// This a tehtar mode for German which follows German orthography closely.
+// It is based on https://web.archive.org/web/20140227102534/http://my.opera.com/tengwarblog/blog/tengwar-orthografischer-deutscher-tehtar-modus
+// I have taken a few elements from other German modes published on the
+// internet and also added some elements of my own.
+//
+//
+// One particular challenge is the encoding of multi-lettered graphemes.
+// Many have natural tengwar candidates which should be used for
+// transcriptions. However, these letter combinations can also occur in cases
+// where they do not constitute one single grapheme, e.g., in composite words
+// or within a prefixed morpheme. For example, the grapheme DSCH, which occurs
+// in words such as Dschungel, is encoded with anga. However, the letter
+// combination also occurs in words such as Grund-schule (hyphen for emphasis
+// only). Here, DSCH is not a single grapheme, but there are two graphemes D
+// and SCH resulting from the individual parts of the composite words. This is
+// also pronounced differently.
+//
+// It is probably impossible for Tecendil to distinguish these cases since it
+// requires semantic knowledge. Moreover, the decomposition into word parts is
+// not even unique in some rare cases: Wachstube could be both Wach-stube and
+// Wachs-tube.
+//
+// This mode errs on the side of "overcollapsing" letters into graphemes,
+// i.e., there are mapping rules for a lot of letter clusters. One can
+// separate word parts by an apostrophe ' in Tecendil input, which prevents
+// mapping rules from being applied "across" the apostrophe. For example,
+// using Grund'schule as input would give the correct transcription.
+// Further mapping or word rules may be added later to make the transcription
+// more accurate, but it is never going to be perfect.
+//
+//
 // TODO LATER check out the following sources
 // https://de.wiktionary.org/wiki/Verzeichnis:Deutsch/Phoneme_und_Grapheme
 // https://de.wiktionary.org/wiki/Verzeichnis:Deutsch/Zweifelsf%C3%A4lle_der_Phonem-Graphem-Zuordnung/Konsonanten
 // https://deutsch.lingolia.com/de/rechtschreibung/konsonanten/th-und-rh
+// ---------------------------------------------------------------------------
+
 
 {
   // Short-name
@@ -76,7 +105,18 @@
     // -----------------------------------------------------------------------
     //
     // DEHNUNGS-H
-    // TODO DISCUSS
+    //
+    // NOTES: Vowel+h usually marks a long vowel in German. This is not
+    // transcribed as vowel+hyarmen for different reasons:
+    // First, the h is not pronounced by itself. Second, placing a tehtar on
+    // hyarmen is a bit of a squeeze. This is a problem of tengwar itself, not
+    // of any particular font. In the original tengwar use cases, there are
+    // not too many cases where one has a tehtar on hyarmen, but this would be
+    // different for German. For these reasons, these letter combinations have
+    // their own transcription, using the long vowel carriar aara. An
+    // alternative choice would be vilya, which is not in use and would be a
+    // good fit for the h sound -- but this sound does not occur in these
+    // combinations as mentioned previously.
     "ah": "[triple-dot-above]{aara}",
     "eh": "[acute]{aara}",
     "oh": "[right-curl]{aara}",
@@ -92,7 +132,11 @@
     // -a
     "aa": "[triple-dot-above]{osse}",
     // -e
-    // TODO explain that we do not transcribe ae, oe, ue as diphthongs
+    // NOTE: ae, oe, ue are sometimes used as substitues for the umlauts ä, ö,
+    // ü. However, they can also occur in other cases where they usually belong
+    // to two syllables, e.g., aktuell. In order to preserve these cases,
+    // there are no rules for ae, oe, ue. This means, however, that umlauts
+    // have to be input as umlauts, and their substitutes cannot be used.
     "ee": "[acute]{yanta}",
     // TODO LATER non-diphthong ie like 'petersilie', 'serviette'
     "ie": "[dot-above]{yanta}",
@@ -151,14 +195,22 @@
     // TODO LATER anca could be used for voiced sch as in 'garage'
     "j": "{anna}",
 
-    // TODO DISCUSS ST AND SP
+    // TODO LATER: ST and SP are sometimes pronounced SCHT/SCHP. Therefore,
+    // they could be transcribed as harma+tinco/parma, but this depends on the
+    // position within a word. For now, they are simply transcribed as
+    // silme+tinco/parma.
 
     // -----------------------------------------------------------------------
     //
     // CONSONANTS: VELARS
     "k": "{quesse}",
     "g": "{ungwe}",
-    // TODO note on the two distinct sounds
+    // CH represents two phonemes, depending on the preceding vowel. Hwesta is
+    // the natural choice for the velar fricativ as in Loch. The other phonem
+    // is a palatal fricative such as in Ich. Ngoldo is unused and could be
+    // used to represent this sound. However, this is an orthographic mode, so
+    // we stick with one tengwar for both phonemes represented by this
+    // graphem.
     "ch": "{hwesta}",
     // In the vast majority of cases, ng is a velar nasal. This includes the
     // common combinations -ing and -ung.
@@ -174,7 +226,21 @@
     "s": "{silme}", // automatically becomes nuquerna with tengwar
     // TODO LATER check for problems at morphem boundaries / check triple s
     "ss": "{esse}", // automatically becomes nuquerna with tengwar
-    // TODO explain (e.g., Masse/Maße)
+    // NOTES: It seems prudent to have a distinct tengwar for ß. This letter
+    // can be transcribed as ss when no ß is available, but ss and ß are two
+    // distinct graphemes, and it is better to keep this distinction to
+    // distinguish certain word pairs, e.g., Masse/Maße. Both ß and ss are
+    // pronounced as voiceless s, but there is still a distinction in
+    // pronounciation of the word, namely ß always follows a long vowel while
+    // ss follows a short one.
+    // Thúle is a good fit for several reasons. First, it is yet unused and
+    // also used for voiceless s in Quenya. Second, it is visually quite
+    // similar to ß. Third, the two different graphemes for voiceless s (ss/ß)
+    // have some historic/linguistic background, and the same is true for
+    // Quenya: Thúle was pronounced as a dental fricative in Aman, but it
+    // became a voiceless s in Middle-Earch. Yet the distinction was kept in
+    // writing, and thúle and silme are both used for the same voiceless s
+    // sound.
     "ß": "{thuule}",
     // Dehnungs-h transcribed in vowel section
     "h": "{hyarmen}",
@@ -225,6 +291,7 @@
     // -----------------------------------------------------------------------
     //
     // CONSONANTS: -W
+    // TODO LATER check for problems at morphem boundaries
     "schw": "[over-twist]{harma}",
     "zw": "[over-twist]{extended-tinco}",
     // tz-w usually occours only in composites tz-w, therefore there is no over-twist.
@@ -316,13 +383,20 @@
     "xion": "[double-dot-below][right-curl-below]{quesse}[right-curl]{nuumen}",
     "xiom": "[double-dot-below][right-curl-below]{quesse}[right-curl]{malta}",
 
-    // TODO NOTES on -E/-S in composites. We could add more -s/-es rules to
-    // allow for encoding in composites when an apostroph is input at the
-    // morphem boundary. The rules here are for actual word endings only.
+    // NOTES: The following rules for final -e/-s/-es can also be used within
+    // words at the end of a word part, e.g., for the s in Lachsforelle. One
+    // can separate word parts by an apostrophe ' in Tecendil input, which
+    // also marks the part before the apostrophe as a word ending.
+    // As of now, -e/-s/-es is only encoded for cases that can appear at the
+    // actual end of a word. More combinations are possible when -e/-s/-es
+    // appear as a Fugenlaut.
+    
+    // TODO LATER add -e/-s/-es combinations for Fugenlaut.
 
     // -----------------------------------------------------------------------
     //
     // FINAL -E
+    // NOTES: In some fonts, dot under aara does not look good.
     "e$": "[dot-below]",
 
     // -----------------------------------------------------------------------

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -153,7 +153,10 @@
     "g": "{ungwe}",
     // TODO: note on the two distinct sounds
     "ch": "{hwesta}",
-    // TODO: exceptions like Kongo, Mango, ungerade
+    // In the vast majority of cases, ng is a velar nasal. This includes the
+    // common combinations -ing and -ung.
+    // Exceptions where the g is pronounced, i.e., ng-g, are transcribed
+    // later.
     "ng": "{nwalme}",
 
     // -----------------------------------------------------------------------
@@ -234,7 +237,7 @@
 
     // -----------------------------------------------------------------------
     //
-    // CONSONANTS: NASALIZED CONSONANTS
+    // CONSONANTS: NASAL + CONSONANTS
     // Note: For the labial series, we encode m+consonant with the tilde.
     // There are some cases where n+labial occurs with prefixes such as an- or
     // un-. However, m+labial seems to be more frequent. This is also
@@ -258,9 +261,22 @@
     "nj": "[tilde-above]{anna}",
 
     "nk": "[tilde-above]{quesse}",
-    // TODO ng-g cases
-    //"ng": "[tilde-above]{ungwe}",
+    // ng see below
     "nch": "[tilde-above]{hwesta}",
+
+    // Some exceptions where ng is pronounced ng-g, transcribed as nasalized g.
+    // Usually happens when a prefix ending with n is used (ungerade) or when
+    // ng is followed by an open vowel (Kongo).
+    // In the vast majority of cases, ng is just a (velar) nasal and
+    // transcribed with ngwalme (defined above).
+    "nga": "[tilde-above]{ungwe}[triple-dot-above]",
+    "ngeh": "[tilde-above]{ungwe}[acute]{aara}",
+    "ngie": "[tilde-above]{ungwe}[dot-above]{yanta}",
+    "ngo": "[tilde-above]{ungwe}[right-curl]",
+    // What about ngi, ngu? TODO CHECK
+    "^ang": "[triple-dot-above][tilde-above]{ungwe}",
+    "^ung": "[left-curl][tilde-above]{ungwe}",
+    "^eing": "[acute]{anna}[tilde-above]{ungwe}",
 
     // TODO what about nl?
     // "nl": "[tilde-above]{lambe}",
@@ -445,5 +461,6 @@
 
   "words":
   {
+      // TODO further ng special cases such as 'Angelika'
   }
 }

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -36,7 +36,25 @@
     "ca": "ka",
     "co": "ko",
     "cu": "ku",
-    "cü": "kü"
+    "cü": "kü",
+
+    // Consonantic y + vowel
+    // TODO CHECK problems at morphem boundaries
+    "ya": "ja",
+    "ye": "je",
+    // yi not known to occur TODO CHECK
+    "yo": "jo",
+    "yu": "ju",
+    // TODO CHECK y+umlaut
+
+    // vowel + y: diphthong
+    "ay": "ai",
+    // ey and ei are not pronounced in the same way, but I have no better idea
+    "ey": "ei"
+    // iy not known to occur TODO CHECK
+    // oy will be directly encoded under diphthongs because oi is not always a
+    // diphthong
+    // uy not known to occur TODO CHECK
   },
 
   "map":
@@ -71,6 +89,8 @@
     // -u
     "au": "[triple-dot-above]{vala}",
     "eu": "[acute]{vala}",
+    // -y when not handled by preprocess
+    "oy": "[right-curl]{anna}",
 
     // TODO consonantic i (ia, io, iu) in certain situations
 

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -24,15 +24,6 @@
     "ii": "i'i",
     "uu": "u'u",
 
-
-    // -i diphthongs with {anna}
-    "ai": "aj",
-    "ei": "ej",
-    // -u diphthongs with {vala}
-    "au": "aw",
-    "eu": "ew",
-
-
     // Replace c+vowel by z or k, depending on following vowel
     // c -> z
     "cä": "zä",
@@ -70,14 +61,16 @@
     "ee": "[acute]{yanta}",
     // TODO non-diphthong ie like 'petersilie', 'serviette'
     "ie": "[dot-above]{yanta}",
-    // -i
-    // ai and ei handled by preprocessing
+    // -i diphthongs with {anna}
+    "ai": "[triple-dot-above]{anna}",
+    "ei": "[acute]{anna}",
     // TODO oi/ui. Sometimes diphthong, sometimes o-i.
     // -o
     // implemented by built-in rule
     // "oo": "[double-right-curl]",
     // -u
-    // au and eu handled by preprocessing
+    "au": "[triple-dot-above]{vala}",
+    "eu": "[acute]{vala}",
 
     // TODO consonantic i (ia, io, iu) in certain situations
 
@@ -91,6 +84,8 @@
     "n": "{nuumen}",
     "z": "{extended-tinco}",
     // r ore implemented by rrule
+    // TODO final -r can appear in the middle of a composite word and should
+    // be ore there
 
     // -----------------------------------------------------------------------
     //
@@ -131,8 +126,6 @@
     //
     // CONSONANTS: MISC SINGLE TENGWAR
     // r romen implemented by rrule
-    // TODO: check for problems at morphem boundaries
-    "rh": "{arda}",
     "l": "{lambe}",
     "s": "{silme}", // automatically becomes nuquerna with tengwar
     // TODO: check for problems at morphem boundaries / check triple s
@@ -156,14 +149,33 @@
     "qu": "[over-twist]{quesse}",
     // Does this ever happen?
     "q": "{quesse}",
-    // We should preprocess too ks here because of words like 'wirksam'
-    "x": "[right-curl-below]{quesse}"
+    // We should not preprocess to ks here because of words like 'wirksam'
+    "x": "[right-curl-below]{quesse}",
 
-    // TODO: consonant diacritics (-h, double, nasal, final s, following w)
-    // TODO: ck
-    // TODO: sp, st
-    // TODO: tz
-    // TODO: consonant diacritics (-h, double, nasal, final s)
+    // -----------------------------------------------------------------------
+    //
+    // CONSONANTS: -H
+    // TODO: this could cause too many problems with composites. could be
+    // better to put the
+    // known words into the words list
+    // TODO are there more consonants with following h?
+    "th": "[thinnas]{tinco}",
+    "rh": "{arda}",
+    "ph": "[thinnas]{parma}",
+    "gh": "[thinnas]{ungwe}",
+
+    // -----------------------------------------------------------------------
+    //
+    // CONSONANTS: FINAL -E and -S
+    // TODO use prettier inside dots for "large" tengwar
+    "e$": "[dot-below]",
+    // TODO: check, does not work with some consonantsn
+    // also should not be used after vowel
+    "s$": "[hook]",
+    // TODO: does not work; the diacritic encondings should be before the
+    // tengwar (but this is ok for e$ above)
+    "es$": "[hook][dot-below]"
+
   },
 
   "words":

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -270,6 +270,16 @@
 
     // -----------------------------------------------------------------------
     //
+    // CONSONANTS: -SION, -SSION, -TION
+    // Special cases where the I is always consonantic. This is a frequent
+    // morphem ending.
+    // TODO check for problems at morphem boundaries
+    "sion": "[double-dot-below]{silme}[right-curl]{nuumen}",
+    "ssion": "[double-dot-inside]{esse}[right-curl]{nuumen}",
+    "tion": "[double-dot-below]{extended-tinco}[right-curl]{nuumen}",
+
+    // -----------------------------------------------------------------------
+    //
     // CONSONANTS: FINAL -E
     // TODO CHECK WITH NEW STUFF
     "e$": "[dot-below]"

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -33,6 +33,7 @@
     // DIPHTHONGS
     //
 
+
     // -----------------------------------------------------------------------
     //
     // CONSONANTS: DENTALS
@@ -40,7 +41,8 @@
     "t": "{tinco}",
     "d": "{ando}",
     "n": "{nuumen}",
-    // r implemented by rrule
+	"z": "{extended-tinco}",
+    // r ore implemented by rrule
 
     // -----------------------------------------------------------------------
     //
@@ -51,18 +53,20 @@
     "v": "{ampa}",
     "m": "{malta}",
     "w": "{vala}",
+	// TODO check for problems at morphem boundaries
+	"pf" : "{extended-parma}"
 
     // -----------------------------------------------------------------------
     //
     // CONSONANTS: POSTALVEOLARS/PALATALS (SCH VARIANTS AND J)
+	// TODO check for problems at morphem boundaries
     "tsch": "{calma}",
-
 	// TODO: maybe only for foreign words like dschungel and remove from map
+	// because of words like 'Grundschule'
     "dsch": "{anga}",
+	// TODO check for problems at morphem boundaries
     "sch": "{harma}",
-
 	// TODO: anca could be used for voiced sch as in 'garage'
-
     "j": "{anna}",
 
     // -----------------------------------------------------------------------
@@ -70,12 +74,35 @@
     // CONSONANTS: VELARS
     "k": "{quesse}",
     "g": "{ungwe}",
-
 	// TODO: note on the two distinct sounds
     "ch": "{hwesta}",
-
 	// TODO: exceptions like Kongo, Mango, ungerade
-	"ng": "{nwalme}"
+	"ng": "{nwalme}",
+
+    // -----------------------------------------------------------------------
+    //
+    // CONSONANTS: MISC
+	// r romen implemented by rrule
+	// TODO: check for problems at morphem boundaries
+    "rh": "{arda}",
+	"l": "{lambe}",
+	// TODO: silme nuquerna with tengwar
+	"s": "{silme}",
+	// TODO: check for problems at morphem boundaries / check triple s
+	"ss": "{esse}",
+	// TODO ß
+	// TODO: Dehnungs-h
+	"h": "{hyarnen}"
+
+	// TODO: consonant diacritics (-h, double, nasal, final s, following w)
+	// TODO: c
+	// TODO: ck
+	// TODO: sp, st
+	// TODO: tz
+	// TODO: x
+	// TODO: Q ->K, QU -> KW
+	// TODO: consonant diacritics (-h, double, nasal, final s
+
   },
 
   "words":

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -1,0 +1,84 @@
+// ---------------------------------------------------------------------------
+//
+// GERMAN ORTHOGRAPHIC MODE
+//
+// ---------------------------------------------------------------------------
+
+// TODO ADD SOURCES, EXPLANATION, ...
+
+{
+  // Short-name
+  "name": "german-orthographic",
+  "languageCode": "de",
+
+  "normalizeVowels": false,
+
+  "tehtarFollow": true,
+
+  "rrule": true,
+
+  "preprocess":
+  {
+  },
+
+  "map":
+  {
+    // -----------------------------------------------------------------------
+    //
+    // VOWELS
+    //
+
+    // -----------------------------------------------------------------------
+    //
+    // DIPHTHONGS
+    //
+
+    // -----------------------------------------------------------------------
+    //
+    // CONSONANTS: DENTALS
+    //
+    "t": "{tinco}",
+    "d": "{ando}",
+    "n": "{nuumen}",
+    // r implemented by rrule
+
+    // -----------------------------------------------------------------------
+    //
+    // CONSONANTS: LABIALS
+    "p": "{parma}",
+    "b": "{umbar}",
+    "f": "{formen}",
+    "v": "{ampa}",
+    "m": "{malta}",
+    "w": "{vala}",
+
+    // -----------------------------------------------------------------------
+    //
+    // CONSONANTS: POSTALVEOLARS/PALATALS (SCH VARIANTS AND J)
+    "tsch": "{calma}",
+
+	// TODO: maybe only for foreign words like dschungel and remove from map
+    "dsch": "{anga}",
+    "sch": "{harma}",
+
+	// TODO: anca could be used for voiced sch as in 'garage'
+
+    "j": "{anna}",
+
+    // -----------------------------------------------------------------------
+    //
+    // CONSONANTS: VELARS
+    "k": "{quesse}",
+    "g": "{ungwe}",
+
+	// TODO: note on the two distinct sounds
+    "ch": "{hwesta}",
+
+	// TODO: exceptions like Kongo, Mango, ungerade
+	"ng": "{nwalme}"
+  },
+
+  "words":
+  {
+  }
+}

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -278,15 +278,16 @@
     "ssion": "[double-dot-inside]{esse}[right-curl]{nuumen}",
     "tion": "[double-dot-below]{extended-tinco}[right-curl]{nuumen}",
 
-    // -----------------------------------------------------------------------
-    //
-    // FINAL -E
-    // TODO CHECK WITH NEW STUFF
-    "e$": "[dot-below]",
+    // TODO NOTES on -E/-S in composites
 
     // -----------------------------------------------------------------------
     //
     // FINAL -E
+    "e$": "[dot-below]",
+
+    // -----------------------------------------------------------------------
+    //
+    // FINAL -S
     // also should not be used after vowel
     "aas$": "[triple-dot-above][hook]{osse}",
     "ees$": "[acute][hook]{yanta}",
@@ -311,11 +312,26 @@
     "pfs$" : "[hook]{extended-parma}",
 
     // -schs, -js does not occur TODO CHECK
-    
     "ks$": "[hook]{quesse}",
     "gs$": "[hook]{ungwe}",
     "chs$": "[hook]{hwesta}",
     "ngs$": "[hook]{nwalme}",
+
+    "ls$": "[hook]{lambe}",
+    // TODO: Dehnungs-h + s
+
+    "cs$": "[hook]{quesse}",
+    // -qus, -qs, -xs does not occur TODO CHECK
+
+    // -dds, -rrs, -zzs, -tzs, -bbs, -kks, -ccs, -ggs do not occur TODO CHECK
+    "tts$": "[bar-below][hook]{tinco}",
+    "nns$": "[bar-below][hook]{nuumen}",
+    "pps$": "[bar-below][hook]{parma}",
+    "ffs$": "[bar-below][hook]{formen}",
+    "mms$": "[bar-below][hook]{malta}",
+    "cks$": "[bar-below][hook]{quesse}",
+    "lls$": "[bar-below][hook]{lambe}",
+
 
     // -----------------------------------------------------------------------
     //
@@ -347,7 +363,32 @@
     // -kes does not occur, only -nkes and -ckes TODO CHECK
     "ges$": "[hook][dot-below]{ungwe}",
     "ches$": "[hook][dot-below]{hwesta}",
-    "nges$": "[hook][dot-below]{nwalme}"
+    "nges$": "[hook][dot-below]{nwalme}",
+
+    "les$": "[hook][dot-below]{lambe}",
+    // TODO: Dehnungs-h + es
+
+    // -ces, -ques, -qes does not occur TODO CHECK
+    "xes$": "[right-curl-below][hook][dot-below]{quesse}",
+
+    // -ddes, -bbes, -kkes, -cces, -gges do not occur TODO CHECK
+    "ttes$": "[bar-below][hook][dot-below]{tinco}",
+    "nnes$": "[bar-below][hook][dot-below]{nuumen}",
+    // does not look good
+    //"rres$": "[bar-below][hook][dot-below]{roomen}",
+    "zzes$": "[bar-below][hook][dot-below]{extended-tinco}",
+    "tzes$": "[bar-below][hook][dot-below]{extended-tinco}",
+    "ppes$": "[bar-below][hook][dot-below]{parma}",
+    "ffes$": "[bar-below][hook][dot-below]{formen}",
+    "mmes$": "[bar-below][hook][dot-below]{malta}",
+    "ckes$": "[bar-below][hook][dot-below]{quesse}",
+    "lles$": "[bar-below][hook][dot-below]{lambe}"
+
+
+
+
+
+
   },
 
   "words":

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -173,7 +173,7 @@
 
     "kk": "[bar-below]{quesse}",
     "ck": "[bar-below]{quesse}",
-    // TODO: cce not working because of preprocessing
+    // TODO: cce/cci not working because of preprocessing
     "cc": "[bar-below]{quesse}",
     "gg": "[bar-below]{ungwe}",
 
@@ -184,7 +184,7 @@
     // CONSONANTS: -W
     "schw": "[over-twist]{harma}",
     "zw": "[over-twist]{extended-tinco}",
-    // tz-w occours only in composites tz-w, therefore there is no over-twist.
+    // tz-w usually occours only in composites tz-w, therefore there is no over-twist.
     // This is already correctly handled because of the tz rule before.
 
     // -----------------------------------------------------------------------
@@ -198,6 +198,55 @@
     "rh": "{arda}",
     "ph": "[thinnas]{parma}",
     "gh": "[thinnas]{ungwe}",
+
+    // -----------------------------------------------------------------------
+    //
+    // CONSONANTS: NASALIZED CONSONANTS
+    // Note: For the labial series, we encode m+consonant with the tilde.
+    // There are some cases where n+labial occurs with prefixes such as an- or
+    // un-. However, m+labial seems to be more frequent. This is also
+    // consistent with the velar series because the 'n' for the first two
+    // combinations is actually a velar nasal and not the usual dental nasal
+    // 'n'.
+    // TODO check for problems at morphem boundaries
+    "nt": "[tilde-above]{tinco}",
+    "nd": "[tilde-above]{ando}",
+    "nz": "[tilde-above]{extended-tinco}",
+
+    "mp": "[tilde-above]{parma}",
+    "mb": "[tilde-above]{umbar}",
+    "mf": "[tilde-above]{formen}",
+    // mv does not occur TODO CHECK
+    "mw": "[tilde-above]{vala}", 
+    "mpf" : "[tilde-above]{extended-parma}",
+
+    // ntsch, ndsch do not occur TODO CHECK
+    "nsch": "[tilde-above]{harma}",
+    // nj better handled as n + palatalization symbol
+
+    "nk": "[tilde-above]{quesse}",
+    // TODO ng-g cases
+    //"ng": "[tilde-above]{ungwe}",
+    "nch": "[tilde-above]{hwesta}",
+
+    // TODO what about nl?
+    // "nl": "[tilde-above]{lambe}",
+    "ns": "[tilde-above]{silme}", // automatically becomes nuquerna with tengwar
+    // TODO nh?
+
+    // nc covered by c+vowel preprocess and n+ch TODO CHECK
+    // nq nx do not occur TODO CHECK
+
+    // ntz is usually nt+z at a morphem boundary, therefore there is no
+    // special rule and it is encoded nt+z TODO CHECK
+
+    // Only known remaining case for n+double consonant TODO CHECK
+    "nck": "[tilde-above][bar-below]{quesse}",
+
+    // nasal + consonant + w should be fine
+    // known cases for nasal+consonant+h TODO CHECK
+    "nth": "[tilde-above][thinnas]{tinco}",
+    "mph": "[tilde-above][thinnas]{parma}",
 
     // -----------------------------------------------------------------------
     //

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -280,20 +280,74 @@
 
     // -----------------------------------------------------------------------
     //
-    // CONSONANTS: FINAL -E
+    // FINAL -E
     // TODO CHECK WITH NEW STUFF
-    "e$": "[dot-below]"
+    "e$": "[dot-below]",
 
     // -----------------------------------------------------------------------
     //
-    // CONSONANTS: FINAL -S
-    // TODO: check, does not work with some consonantsn
+    // FINAL -E
     // also should not be used after vowel
-    // "s$": "[hook]",
-    // TODO: does not work; the diacritic encondings should be before the
-    // tengwar (but this is ok for e$ above)
-    //"es$": "[hook][dot-below]"
+    "aas$": "[triple-dot-above][hook]{osse}",
+    "ees$": "[acute][hook]{yanta}",
+    "ies$": "[dot-above][hook]{yanta}",
+    "ais$": "[triple-dot-above][hook]{anna}",
+    "eis$": "[acute][hook]{anna}",
+    "aus$": "[triple-dot-above][hook]{vala}",
+    "eus$": "[acute][hook]{vala}",
+    "oys$": "[right-curl][hook]{anna}",
 
+    "ts$": "[hook]{tinco}",
+    "ds$": "[hook]{ando}",
+    "ns$": "[hook]{nuumen}",
+    "rs$": "[hook]{oore}",
+
+    "ps$": "[hook]{parma}",
+    "bs$": "[hook]{umbar}",
+    "fs$": "[hook]{formen}",
+    // vs does not occur TODO CHECK
+    "ms$": "[hook]{malta}",
+    // ws does not occur TODO CHECK
+    "pfs$" : "[hook]{extended-parma}",
+
+    // -schs, -js does not occur TODO CHECK
+    
+    "ks$": "[hook]{quesse}",
+    "gs$": "[hook]{ungwe}",
+    "chs$": "[hook]{hwesta}",
+    "ngs$": "[hook]{nwalme}",
+
+    // -----------------------------------------------------------------------
+    //
+    // FINAL -ES
+    // -aaes, -eees, -iees, -yoes do not occur TODO CHECK
+    "aies$": "[triple-dot-above][hook][dot-below]{anna}",
+    "eies$": "[acute][hook][dot-below]{anna}",
+    "aues$": "[triple-dot-above][hook][dot-below]{vala}",
+    "eues$": "[acute][hook][dot-below]{vala}",
+
+    "tes$": "[hook][dot-below]{tinco}",
+    "des$": "[hook][dot-below]{ando}",
+    "nes$": "[hook][dot-below]{nuumen}",
+    // does not look good
+    // "res$": "[hook][dot-below]{roomen}"
+
+    "pes$": "[hook][dot-below]{parma}",
+    "bes$": "[hook][dot-below]{umbar}",
+    "fes$": "[hook][dot-below]{formen}",
+    "ves$": "[hook][dot-below]{ampa}",
+    "mes$": "[hook][dot-below]{malta}",
+    "wes$": "[hook][dot-below]{vala}",
+    "pfes$" : "[hook][dot-below]{extended-parma}",
+
+    // -dsches, -jes does not occur TODO CHECK
+    "tsches$": "[hook][dot-below]{calma}",
+    "sches$": "[hook][dot-below]{harma}",
+
+    // -kes does not occur, only -nkes and -ckes TODO CHECK
+    "ges$": "[hook][dot-below]{ungwe}",
+    "ches$": "[hook][dot-below]{hwesta}",
+    "nges$": "[hook][dot-below]{nwalme}"
   },
 
   "words":

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -6,6 +6,11 @@
 
 // TODO ADD SOURCES, EXPLANATION, ...
 
+// TODO LATER check out the following sources
+// https://de.wiktionary.org/wiki/Verzeichnis:Deutsch/Phoneme_und_Grapheme
+// https://de.wiktionary.org/wiki/Verzeichnis:Deutsch/Zweifelsf%C3%A4lle_der_Phonem-Graphem-Zuordnung/Konsonanten
+// https://deutsch.lingolia.com/de/rechtschreibung/konsonanten/th-und-rh
+
 {
   // Short-name
   "name": "german-orthographic",
@@ -39,22 +44,22 @@
     "cü": "kü",
 
     // Consonantic y + vowel
-    // TODO CHECK problems at morphem boundaries
+    // TODO LATER CHECK problems at morphem boundaries
     "ya": "ja",
     "ye": "je",
-    // yi not known to occur TODO CHECK
+    // yi not known to occur TODO LATER CHECK
     "yo": "jo",
     "yu": "ju",
-    // TODO CHECK y+umlaut
+    // TODO LATER CHECK y+umlaut
 
     // vowel + y: diphthong
     "ay": "ai",
     // ey and ei are not pronounced in the same way, but I have no better idea
     "ey": "ei"
-    // iy not known to occur TODO CHECK
+    // iy not known to occur TODO LATER CHECK
     // oy will be directly encoded under diphthongs because oi is not always a
     // diphthong
-    // uy not known to occur TODO CHECK
+    // uy not known to occur TODO LATER CHECK
   },
 
   "map":
@@ -89,12 +94,12 @@
     // -e
     // TODO explain that we do not transcribe ae, oe, ue as diphthongs
     "ee": "[acute]{yanta}",
-    // TODO non-diphthong ie like 'petersilie', 'serviette'
+    // TODO LATER non-diphthong ie like 'petersilie', 'serviette'
     "ie": "[dot-above]{yanta}",
     // -i diphthongs with {anna}
     "ai": "[triple-dot-above]{anna}",
     "ei": "[acute]{anna}",
-    // TODO oi/ui. Sometimes diphthong, sometimes o-i.
+    // TODO LATER oi/ui. Sometimes diphthong, sometimes o-i.
     // -o
     // implemented by built-in rule
     // "oo": "[double-right-curl]",
@@ -104,9 +109,9 @@
     // -y when not handled by preprocess
     "oy": "[right-curl]{anna}",
 
-    // TODO use thinnas for diphthong+h, maybe only at end of word?
+    // TODO LATER use thinnas for diphthong+h, maybe only at end of word?
 
-    // TODO consonantic i (ia, io, iu) in certain situations?
+    // TODO LATER consonantic i (ia, io, iu) in certain situations?
 
 
     // -----------------------------------------------------------------------
@@ -118,7 +123,7 @@
     "n": "{nuumen}",
     "z": "{extended-tinco}",
     // r ore implemented by rrule
-    // TODO final -r can appear in the middle of a composite word and should
+    // TODO LATER final -r can appear in the middle of a composite word and should
     // be ore there
 
     // -----------------------------------------------------------------------
@@ -130,28 +135,30 @@
     "v": "{ampa}",
     "m": "{malta}",
     "w": "{vala}",
-    // TODO check for problems at morphem boundaries
+    // TODO LATER check for problems at morphem boundaries
     "pf" : "{extended-parma}",
 
     // -----------------------------------------------------------------------
     //
     // CONSONANTS: POSTALVEOLARS/PALATALS (SCH VARIANTS AND J)
-    // TODO check for problems at morphem boundaries
+    // TODO LATER check for problems at morphem boundaries
     "tsch": "{calma}",
-    // TODO: maybe only for foreign words like dschungel and remove from map
+    // TODO LATER maybe only for foreign words like dschungel and remove from map
     // because of words like 'Grundschule'
     "dsch": "{anga}",
-    // TODO check for problems at morphem boundaries
+    // TODO LATER check for problems at morphem boundaries
     "sch": "{harma}",
-    // TODO: anca could be used for voiced sch as in 'garage'
+    // TODO LATER anca could be used for voiced sch as in 'garage'
     "j": "{anna}",
+
+    // TODO DISCUSS ST AND SP
 
     // -----------------------------------------------------------------------
     //
     // CONSONANTS: VELARS
     "k": "{quesse}",
     "g": "{ungwe}",
-    // TODO: note on the two distinct sounds
+    // TODO note on the two distinct sounds
     "ch": "{hwesta}",
     // In the vast majority of cases, ng is a velar nasal. This includes the
     // common combinations -ing and -ung.
@@ -165,11 +172,11 @@
     // r romen implemented by rrule
     "l": "{lambe}",
     "s": "{silme}", // automatically becomes nuquerna with tengwar
-    // TODO: check for problems at morphem boundaries / check triple s
+    // TODO LATER check for problems at morphem boundaries / check triple s
     "ss": "{esse}", // automatically becomes nuquerna with tengwar
     // TODO explain (e.g., Masse/Maße)
     "ß": "{thuule}",
-    // TODO: Dehnungs-h
+    // Dehnungs-h transcribed in vowel section
     "h": "{hyarmen}",
 
     // -----------------------------------------------------------------------
@@ -192,7 +199,7 @@
     // CONSONANTS: DOUBLED CONSONANTS
     // Note: tripled consonants are handled correctly, i.e., ff-f, same is
     // true for ck-k
-    // TODO check for problems at morphem boundaries
+    // TODO LATER check for problems at morphem boundaries
     "tt": "[bar-below]{tinco}",
     "dd": "[bar-below]{ando}",
     "nn": "[bar-below]{nuumen}",
@@ -209,7 +216,7 @@
 
     "kk": "[bar-below]{quesse}",
     "ck": "[bar-below]{quesse}",
-    // TODO: cce/cci not working because of preprocessing
+    // TODO LATER cce/cci not working because of preprocessing
     "cc": "[bar-below]{quesse}",
     "gg": "[bar-below]{ungwe}",
 
@@ -226,10 +233,10 @@
     // -----------------------------------------------------------------------
     //
     // CONSONANTS: -H
-    // TODO: this could cause too many problems with composites. could be
+    // TODO LATER this could cause too many problems with composites. could be
     // better to put the
     // known words into the words list
-    // TODO are there more consonants with following h?
+    // TODO LATER are there more consonants with following h?
     "th": "[thinnas]{tinco}",
     "rh": "{arda}",
     "ph": "[thinnas]{parma}",
@@ -244,7 +251,7 @@
     // consistent with the velar series because the 'n' for the first two
     // combinations is actually a velar nasal and not the usual dental nasal
     // 'n'.
-    // TODO check for problems at morphem boundaries
+    // TODO LATER check for problems at morphem boundaries
     "nt": "[tilde-above]{tinco}",
     "nd": "[tilde-above]{ando}",
     "nz": "[tilde-above]{extended-tinco}",
@@ -252,11 +259,11 @@
     "mp": "[tilde-above]{parma}",
     "mb": "[tilde-above]{umbar}",
     "mf": "[tilde-above]{formen}",
-    // mv does not occur TODO CHECK
+    // mv does not occur TODO LATER CHECK
     "mw": "[tilde-above]{vala}", 
     "mpf" : "[tilde-above]{extended-parma}",
 
-    // ntsch, ndsch do not occur TODO CHECK
+    // ntsch, ndsch do not occur TODO LATER CHECK
     "nsch": "[tilde-above]{harma}",
     "nj": "[tilde-above]{anna}",
 
@@ -273,27 +280,27 @@
     "ngeh": "[tilde-above]{ungwe}[acute]{aara}",
     "ngie": "[tilde-above]{ungwe}[dot-above]{yanta}",
     "ngo": "[tilde-above]{ungwe}[right-curl]",
-    // What about ngi, ngu? TODO CHECK
+    // What about ngi, ngu? TODO LATER CHECK
     "^ang": "[triple-dot-above][tilde-above]{ungwe}",
     "^ung": "[left-curl][tilde-above]{ungwe}",
     "^eing": "[acute]{anna}[tilde-above]{ungwe}",
 
-    // TODO what about nl?
+    // TODO LATER what about nl?
     // "nl": "[tilde-above]{lambe}",
     "ns": "[tilde-above]{silme}", // automatically becomes nuquerna with tengwar
-    // TODO nh?
+    // TODO LATER nh?
 
-    // nc covered by c+vowel preprocess and n+ch TODO CHECK
-    // nq nx do not occur TODO CHECK
+    // nc covered by c+vowel preprocess and n+ch TODO LATER CHECK
+    // nq nx do not occur TODO LATER CHECK
 
     // ntz is usually nt+z at a morphem boundary, therefore there is no
-    // special rule and it is encoded nt+z TODO CHECK
+    // special rule and it is encoded nt+z TODO LATER CHECK
 
-    // Only known remaining case for n+double consonant TODO CHECK
+    // Only known remaining case for n+double consonant TODO LATER CHECK
     "nck": "[tilde-above][bar-below]{quesse}",
 
     // nasal + consonant + w should be fine
-    // known cases for nasal+consonant+h TODO CHECK
+    // known cases for nasal+consonant+h TODO LATER CHECK
     "nth": "[tilde-above][thinnas]{tinco}",
     "mph": "[tilde-above][thinnas]{parma}",
 
@@ -302,7 +309,7 @@
     // CONSONANTS: -SION, -SSION, -TION
     // Special cases where the I is always consonantic. This is a frequent
     // morphem ending.
-    // TODO check for problems at morphem boundaries
+    // TODO LATER check for problems at morphem boundaries
     "sion": "[double-dot-below]{silme}[right-curl]{nuumen}",
     "ssion": "[double-dot-inside]{esse}[right-curl]{nuumen}",
     "tion": "[double-dot-below]{extended-tinco}[right-curl]{nuumen}",
@@ -339,12 +346,12 @@
     "ps$": "[hook]{parma}",
     "bs$": "[hook]{umbar}",
     "fs$": "[hook]{formen}",
-    // vs does not occur TODO CHECK
+    // vs does not occur TODO LATER CHECK
     "ms$": "[hook]{malta}",
-    // ws does not occur TODO CHECK
+    // ws does not occur TODO LATER CHECK
     "pfs$" : "[hook]{extended-parma}",
 
-    // -schs, -js does not occur TODO CHECK
+    // -schs, -js does not occur TODO LATER CHECK
     "ks$": "[hook]{quesse}",
     "gs$": "[hook]{ungwe}",
     "chs$": "[hook]{hwesta}",
@@ -354,9 +361,9 @@
     // TODO: Dehnungs-h + s
 
     "cs$": "[hook]{quesse}",
-    // -qus, -qs, -xs does not occur TODO CHECK
+    // -qus, -qs, -xs does not occur TODO LATER CHECK
 
-    // -dds, -rrs, -zzs, -tzs, -bbs, -kks, -ccs, -ggs do not occur TODO CHECK
+    // -dds, -rrs, -zzs, -tzs, -bbs, -kks, -ccs, -ggs do not occur TODO LATER CHECK
     "tts$": "[bar-below][hook]{tinco}",
     "nns$": "[bar-below][hook]{nuumen}",
     "pps$": "[bar-below][hook]{parma}",
@@ -367,11 +374,11 @@
 
     // -schws, -zws do not occur
     
-    // -rhs, -ghs, do not occur TODO CHECK
+    // -rhs, -ghs, do not occur TODO LATER CHECK
     "ths$": "[thinnas][hook]{tinco}",
     "phs$": "[thinnas][hook]{parma}",
 
-    // -nzs, -mbs, -mfs, -mws, -nschs, -njs, -nchs do not occur TODO CHECK
+    // -nzs, -mbs, -mfs, -mws, -nschs, -njs, -nchs do not occur TODO LATER CHECK
     "nts$": "[tilde-above][hook]{tinco}",
     "nds$": "[tilde-above][hook]{ando}",
     "mps$": "[tilde-above][hook]{parma}",
@@ -381,13 +388,13 @@
     "nths$": "[tilde-above][thinnas][hook]{tinco}",
     "mphs$": "[tilde-above][thinnas][hook]{parma}",
 
-    // -sions, -ssions, -tions, -xions do not occur TODO CHECK
+    // -sions, -ssions, -tions, -xions do not occur TODO LATER CHECK
     "xioms$": "[double-dot-below][right-curl-below]{quesse}[right-curl][hook]{malta}",
 
     // -----------------------------------------------------------------------
     //
     // FINAL -ES
-    // -aaes, -eees, -iees, -yoes do not occur TODO CHECK
+    // -aaes, -eees, -iees, -yoes do not occur TODO LATER CHECK
     "aies$": "[triple-dot-above][hook][dot-below]{anna}",
     "eies$": "[acute][hook][dot-below]{anna}",
     "aues$": "[triple-dot-above][hook][dot-below]{vala}",
@@ -407,11 +414,11 @@
     "wes$": "[hook][dot-below]{vala}",
     "pfes$" : "[hook][dot-below]{extended-parma}",
 
-    // -dsches, -jes does not occur TODO CHECK
+    // -dsches, -jes does not occur TODO LATER CHECK
     "tsches$": "[hook][dot-below]{calma}",
     "sches$": "[hook][dot-below]{harma}",
 
-    // -kes does not occur, only -nkes and -ckes TODO CHECK
+    // -kes does not occur, only -nkes and -ckes TODO LATER CHECK
     "ges$": "[hook][dot-below]{ungwe}",
     "ches$": "[hook][dot-below]{hwesta}",
     "nges$": "[hook][dot-below]{nwalme}",
@@ -419,10 +426,10 @@
     "les$": "[hook][dot-below]{lambe}",
     // TODO: Dehnungs-h + es
 
-    // -ces, -ques, -qes does not occur TODO CHECK
+    // -ces, -ques, -qes does not occur TODO LATER CHECK
     "xes$": "[right-curl-below][hook][dot-below]{quesse}",
 
-    // -ddes, -bbes, -kkes, -cces, -gges do not occur TODO CHECK
+    // -ddes, -bbes, -kkes, -cces, -gges do not occur TODO LATER CHECK
     "ttes$": "[bar-below][hook][dot-below]{tinco}",
     "nnes$": "[bar-below][hook][dot-below]{nuumen}",
     // does not look good
@@ -437,12 +444,12 @@
 
     // -schwes, -zwes do not occur
 
-    // -rhes, -ghes, do not occur TODO CHECK
+    // -rhes, -ghes, do not occur TODO LATER CHECK
     // possible, but does not look good
     // "thes$": "[thinnas][hook][dot-below]{tinco}",
     // "phes$": "[thinnas][hook][dot-below]{parma}"
 
-    // -mfes, -mwes, -njes, -nckes do not occur TODO CHECK
+    // -mfes, -mwes, -njes, -nckes do not occur TODO LATER CHECK
     "ntes$": "[tilde-above][hook][dot-below]{tinco}",
     "ndes$": "[tilde-above][hook][dot-below]{ando}",
     "nzes$": "[tilde-above][hook][dot-below]{extended-tinco}",
@@ -456,11 +463,11 @@
     // "nthes$": "[tilde-above][thinnas][hook][dot-below]{tinco}",
     // "mphes$": "[tilde-above][thinnas][hook][dot-below]{parma}"
 
-    // -siones, -ssiones, -tiones, -xiones, -xiomes do not occur TODO CHECK
+    // -siones, -ssiones, -tiones, -xiones, -xiomes do not occur TODO LATER CHECK
   },
 
   "words":
   {
-      // TODO further ng special cases such as 'Angelika'
+      // TODO LATER further ng special cases such as 'Angelika'
   }
 }

--- a/modes/german-orthographic.jsonc
+++ b/modes/german-orthographic.jsonc
@@ -92,7 +92,7 @@
     // -y when not handled by preprocess
     "oy": "[right-curl]{anna}",
 
-    // TODO consonantic i (ia, io, iu) in certain situations
+    // TODO consonantic i (ia, io, iu) in certain situations?
 
 
     // -----------------------------------------------------------------------
@@ -153,7 +153,6 @@
     // TODO explain (e.g., Masse/Maße)
     "ß": "{thuule}",
     // TODO: Dehnungs-h
-    // TODO: consonantic y
     "h": "{hyarmen}",
 
     // -----------------------------------------------------------------------
@@ -277,6 +276,8 @@
     "sion": "[double-dot-below]{silme}[right-curl]{nuumen}",
     "ssion": "[double-dot-inside]{esse}[right-curl]{nuumen}",
     "tion": "[double-dot-below]{extended-tinco}[right-curl]{nuumen}",
+    "xion": "[double-dot-below][right-curl-below]{quesse}[right-curl]{nuumen}",
+    "xiom": "[double-dot-below][right-curl-below]{quesse}[right-curl]{malta}",
 
     // TODO NOTES on -E/-S in composites. We could add more -s/-es rules to
     // allow for encoding in composites when an apostroph is input at the
@@ -350,7 +351,8 @@
     "nths$": "[tilde-above][thinnas][hook]{tinco}",
     "mphs$": "[tilde-above][thinnas][hook]{parma}",
 
-    // -sions, -ssions, -tions do not occur TODO CHECK
+    // -sions, -ssions, -tions, -xions do not occur TODO CHECK
+    "xioms$": "[double-dot-below][right-curl-below]{quesse}[right-curl][hook]{malta}",
 
     // -----------------------------------------------------------------------
     //
@@ -424,7 +426,7 @@
     // "nthes$": "[tilde-above][thinnas][hook][dot-below]{tinco}",
     // "mphes$": "[tilde-above][thinnas][hook][dot-below]{parma}"
 
-    // -siones, -ssiones, -tiones do not occur TODO CHECK
+    // -siones, -ssiones, -tiones, -xiones, -xiomes do not occur TODO CHECK
   },
 
   "words":


### PR DESCRIPTION
Added new mode file for a German orthographic mode.

Some improvements are planned (see comments in mode file). If this is included in Tecendil, it would be great to have it linked to German wikipedia for additional testing.