### PR TITLE
Updated instructions for LaTeX.

### DIFF
--- a/modes/README.md
+++ b/modes/README.md
@@ -163,7 +163,8 @@ with an encoding matching the one of your local font.
 [2] http://www.evertype.com/standards/iso10646/pdf/tengwar.pdf
 
 [3] Tengwar and LaTex:
-https://tex.stackexchange.com/a/169156/170418
+- http://get-software.net/macros/latex/contrib/tengwarscript/tengwarscript.pdf
+- https://tex.stackexchange.com/a/169156/170418
 
 [4] Telcontar Unicode encoding:
 http://freetengwar.sourceforge.net/html-files/tengtelc-discussion-008.pdf

--- a/modes/README.md
+++ b/modes/README.md
@@ -163,7 +163,7 @@ with an encoding matching the one of your local font.
 [2] http://www.evertype.com/standards/iso10646/pdf/tengwar.pdf
 
 [3] Tengwar and LaTex:
-http://get-software.net/macros/latex/contrib/tengwarscript/tengwarscript.pdf
+https://tex.stackexchange.com/a/169156/170418
 
 [4] Telcontar Unicode encoding:
 http://freetengwar.sourceforge.net/html-files/tengtelc-discussion-008.pdf


### PR DESCRIPTION
The `tengwarscript` package is outdated. XeLaTeX with `fontspec` is the modern way to type Unicode characters.