### PR TITLE
fix(spanish.jsonc): fix ió diphthong

### DIFF
--- a/modes/spanish.jsonc
+++ b/modes/spanish.jsonc
@@ -122,7 +122,7 @@ accent - lambe - malta + right curl.
 
     "iá": "[double-dot-below]{aara}[triple-dot-above]{}",
     "ié": "[double-dot-below][double-acute]{}",
-    "ió": "[double-dot-below][double-acute]{}",
+    "ió": "[double-dot-below][double-right-curl]{}",
     "iú": "[double-dot-below][double-left-curl]{}",
 
     // The tehtar of u-dipthongs may overlap


### PR DESCRIPTION
By chance I wrote a word with an "ió" diphthong and I realized that the ó is being written with a double acute, not with a double right curl:
![image](https://user-images.githubusercontent.com/42006607/188169390-2c265b90-a6b8-4aa9-b0eb-21b59a6605af.png)

I fixed this in the `spanish.jsonc` file, but I just realized something else that did not allow me to test properly. On Tecendil, if I write the double right curl _on the Español mode_ it does not render:
![image](https://user-images.githubusercontent.com/42006607/188169741-3edb8ac0-89ca-45de-beea-cf13bbfb7631.png)

and this behavior persist on other modes (e.g Deutsch):
![image](https://user-images.githubusercontent.com/42006607/188169897-8a6c70e8-5764-4ba8-8f7a-27a8d5635cfa.png)

but in others (e.g. English) the behavior is the correct one:
![image](https://user-images.githubusercontent.com/42006607/188169998-14f84517-538e-41ca-bce3-1954af6d5369.png)

I'm at a loss as to what is happening here, but I decided to raise the PR nonetheless to fix the small mistake and to inform you.