### PR TITLE
Fix hook in ays$ map

### DIFF
--- a/modes/english.jsonc
+++ b/modes/english.jsonc
@@ -458,7 +458,7 @@
     // Following s can be indicated by a downward hook
     // "“especially in the combinations ts, ps, ks (x), that were favoured in Quenya”
     // http://at.mansbjorkman.net/teng_quenya.htm
-    "ays$": "[triple-dot-above]{anna}[hook]{}",
+    "ays$": "[triple-dot-above][hook]{anna}",
     "bs$": "[hook-looped-left]{umbar}",
     "des$": "[hook][dot-below]{ando}",
     "ds$": "[hook]{ando}",


### PR DESCRIPTION
Currently, the `ays$` map writes a triple dot above anna (as per the diphthong), plus a hook attached to a telco
![image](https://user-images.githubusercontent.com/42006607/196184647-2b423277-d651-4e9e-b243-d569d0d01532.png)
but the hook should be attached to anna
![image](https://user-images.githubusercontent.com/42006607/196185149-2adad492-8364-46cc-8978-f3bc02e9294c.png)
Given that `"tehtarFollow": true`, I just moved `[hook]` before `{anna}`, and delete the telco `{}`.